### PR TITLE
Fix completely contained option"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test.html
 *.swp
 *un~
 node_modules

--- a/src/Arcs1DTrack.js
+++ b/src/Arcs1DTrack.js
@@ -287,6 +287,7 @@ export default function Arcs1DTrack(HGC, ...args) {
           trackHeight,
           startField: this.options.startField,
           endField: this.options.endField,
+          completelyContained: this.options.completelyContained,
           isFlipped: this.flip,
           minResolution: MIN_RESOLUTION,
         });

--- a/src/arcs-worker.js
+++ b/src/arcs-worker.js
@@ -83,6 +83,7 @@ const worker = function worker() {
     isFlipped = false,
     minResolution = 10,
     minDistance = 2,
+    completelyContained = false,
   }) => {
     const xScale = createScale().domain(xScaleDomain).range(xScaleRange);
 
@@ -100,6 +101,11 @@ const worker = function worker() {
       const x1 = xScale(getStart(item));
       const x2 = xScale(getEnd(item));
       const distance = Math.abs(x1 - x2);
+
+      if (completelyContained && (x1 < xScaleRange[0] || x2 > xScaleRange[1])) {
+        // one end of this
+        return null;
+      }
 
       // Points are too close. There's no point in drawing an arc
       if (distance < minDistance) return null;
@@ -158,6 +164,7 @@ const worker = function worker() {
     isFlipped = false,
     minResolution = 10,
     minDistance = 1,
+    completelyContained = false,
   }) => {
     const heightScale = createScale()
       .domain([0, maxDistance])
@@ -183,6 +190,11 @@ const worker = function worker() {
       const x1 = xScale(start);
       const x2 = xScale(end);
       const distance = Math.abs(x1 - x2);
+
+      if (completelyContained && (x1 < xScaleRange[0] || x2 > xScaleRange[1])) {
+        // one end of this
+        return null;
+      }
 
       // Points are too close. There's no point in drawing an arc
       if (distance < minDistance) return null;


### PR DESCRIPTION
This option only shows interactions that are completely contained within the viewport. It was ignored in the worker code. With this PR it's not.

With option:

![image](https://user-images.githubusercontent.com/2143629/137416563-63dc6f6e-616e-4c56-9493-1220a832b60c.png)

Without option:

![image](https://user-images.githubusercontent.com/2143629/137416587-a5e49b44-13f6-48f4-93a0-4af5b21fe8d9.png)
