### PR TITLE
Fixed the jumping arcs bug

### DIFF
--- a/src/Arcs1DTrack.js
+++ b/src/Arcs1DTrack.js
@@ -300,7 +300,7 @@ export default function Arcs1DTrack(HGC, ...args) {
 
       this.getBuffers(
         Object.values(this.fetchedTiles).flatMap((tile) => tile.tileData)
-      ).then(({ positions, offsets, indices }) => {
+      ).then(({ positions, offsets, indices, xScaleDomain, xScaleRange }) => {
         if (renderCall !== this.renderCall) return;
 
         const uniforms = new PIXI.UniformGroup({
@@ -362,8 +362,8 @@ export default function Arcs1DTrack(HGC, ...args) {
         if (oldMesh) oldMesh.destroy();
 
         this.drawnAtScale = scaleLinear()
-          .domain([...this.xScale().domain()])
-          .range([...this.xScale().range()]);
+          .domain([...xScaleDomain])
+          .range([...xScaleRange]);
 
         scaleGraphics(this.arcsGraphics, this._xScale, this.drawnAtScale);
 

--- a/src/arcs-worker.js
+++ b/src/arcs-worker.js
@@ -329,6 +329,8 @@ const worker = function worker() {
           positions: buffers.positions,
           offsets: buffers.offsets,
           indices: buffers.indices,
+          xScaleDomain: event.data.xScaleDomain,
+          xScaleRange: event.data.xScaleRange,
         },
         [
           buffers.positions.buffer,


### PR DESCRIPTION
Fixed a bug where the arcs appeared to jump around. This was because the `drawnAtScale` wasn't being set to the scale that was used when drawing the arcs in the worker.